### PR TITLE
Modify wait_on_address to have a value rather than address. It helps with enum usage

### DIFF
--- a/common/src/call_once.c
+++ b/common/src/call_once.c
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "azure_macro_utils/macro_utils.h"
+
 #include "azure_c_logging/xlogging.h"
 
 #include "azure_c_pal/interlocked.h"
@@ -16,8 +18,12 @@ MU_DEFINE_ENUM_STRINGS(CALL_ONCE_RESULT, CALL_ONCE_RESULT_VALUES);
 /*a weak check to ensure that nobody has the idea to change call_once_t type to int8_t (or other type...  to save some memory for example)*/
 static int check_call_once_t_is_the_same_as_volatile_atomic_int32_t_because_we_are_going_to_pass_it_to_wait_on_address_or_wake_by_address_all[sizeof(volatile_atomic int32_t) == sizeof(call_once_t)];
 
-static int32_t CALL_ONCE_CALLING = CALL_ONCE_NOT_CALLED + 1; /*at least CALL_ONCE_CALLING needs to be a variable because it will have its address taken (wait_on_address needs that). So it cannot be an enum or #define or "2"*/
-static const int32_t CALL_ONCE_CALLED = CALL_ONCE_NOT_CALLED + 2;
+#define CALL_ONCE_STATE_VALUES \
+    CALL_ONCE_STATE_NOT_CALLED = CALL_ONCE_NOT_CALLED, \
+    CALL_ONCE_STATE_CALLING, \
+    CALL_ONCE_STATE_CALLED
+
+MU_DEFINE_ENUM_WITHOUT_INVALID(CALL_ONCE_STATE, CALL_ONCE_STATE_VALUES)
 
 /*returns CALL_ONCE_PROCEED if calling code should do proceed to call the code, any other value = code already called*/
 CALL_ONCE_RESULT call_once_begin(call_once_t* state)
@@ -32,9 +38,9 @@ CALL_ONCE_RESULT call_once_begin(call_once_t* state)
 
     /*Codes_SRS_CALL_ONCE_02_001: [ call_once_begin shall use interlocked_compare_exchange(state, 1, 0) to determine if user has alredy indicated that the init code was executed with success. ]*/
     /*Codes_SRS_CALL_ONCE_02_002: [ If interlocked_compare_exchange returns 2 then call_once_begin shall return CALL_ONCE_ALREADY_CALLED. ]*/
-    while ((state_local = interlocked_compare_exchange(state, CALL_ONCE_CALLING, CALL_ONCE_NOT_CALLED)) != CALL_ONCE_CALLED)
+    while ((state_local = interlocked_compare_exchange(state, CALL_ONCE_STATE_CALLING, CALL_ONCE_STATE_NOT_CALLED)) != CALL_ONCE_STATE_CALLED)
     {
-        if (state_local == CALL_ONCE_NOT_CALLED) /*it was not initialized, now it is "1" (initializing)*/
+        if (state_local == CALL_ONCE_STATE_NOT_CALLED) /*it was not initialized, now it is "1" (initializing)*/
         {
             /*Codes_SRS_CALL_ONCE_02_004: [ If interlocked_compare_exchange returns 0 then call_once_begin shall return CALL_ONCE_PROCEED. ]*/
             /*only 1 thread can get here, (the current one) so letting it proceed to initialize*/
@@ -45,7 +51,7 @@ CALL_ONCE_RESULT call_once_begin(call_once_t* state)
         {
             /*Codes_SRS_CALL_ONCE_02_003: [ If interlocked_compare_exchange returns 1 then call_once_begin shall call wait_on_address(state) with timeout UINT32_MAX and call again interlocked_compare_exchange(state, 1, 0). ]*/
             /*state cannot be "2" because while condition, so that means state is "1", and that means, need to wait until it is not 1*/
-            if (!wait_on_address(state, &CALL_ONCE_CALLING, UINT32_MAX))
+            if (!wait_on_address(state, CALL_ONCE_STATE_CALLING, UINT32_MAX))
             {
                 /*look the other way and retry*/
                 LogError("failure in wait_on_address, var=%p", state);
@@ -63,7 +69,7 @@ void call_once_end(call_once_t* state, bool success)
 {
     /*Codes_SRS_CALL_ONCE_02_005: [ If success is true then call_once_end shall call interlocked_exchange setting state to CALL_ONCE_CALLED and shall call wake_by_address_all(state). ]*/
     /*Codes_SRS_CALL_ONCE_02_006: [ If success is false then call_once_end shall call interlocked_exchange setting state to CALL_ONCE_NOT_CALLED and shall call wake_by_address_all(state). ]*/
-    (void)interlocked_exchange(state, success ? CALL_ONCE_CALLED : CALL_ONCE_NOT_CALLED);
+    (void)interlocked_exchange(state, success ? CALL_ONCE_STATE_CALLED : CALL_ONCE_STATE_NOT_CALLED);
     wake_by_address_all(state);
 }
 

--- a/interfaces/inc/azure_c_pal/sync.h
+++ b/interfaces/inc/azure_c_pal/sync.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t*, compare_address, uint32_t, timeout_ms);
+MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t, compare_value, uint32_t, timeout_ms);
 MOCKABLE_FUNCTION(, void, wake_by_address_all, volatile_atomic int32_t*, address);
 MOCKABLE_FUNCTION(, void, wake_by_address_single, volatile_atomic int32_t*, address);
 

--- a/interfaces/reals/real_sync.h
+++ b/interfaces/reals/real_sync.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 
-bool real_wait_on_address(volatile_atomic int32_t* address, int32_t* compare_address, uint32_t timeout_ms);
+bool real_wait_on_address(volatile_atomic int32_t* address, int32_t compare_value, uint32_t timeout_ms);
 void real_wake_by_address_all(volatile_atomic int32_t* address);
 void real_wake_by_address_single(volatile_atomic int32_t* address);
 

--- a/interfaces/tests/file_int/file_int.c
+++ b/interfaces/tests/file_int/file_int.c
@@ -65,14 +65,14 @@ static void read_callback(void* context, bool is_successful)
     wake_by_address_single(&read_context->value);
 }
 
-static void wait_on_address_helper(volatile_atomic int32_t* address, int32_t* old_value, uint32_t timeout)
+static void wait_on_address_helper(volatile_atomic int32_t* address, int32_t old_value, uint32_t timeout)
 {
     int32_t current_value;
     do
     {
         wait_on_address(address, old_value, timeout);
         current_value = interlocked_add(address, 0);
-    } while (current_value == *old_value);
+    } while (current_value == old_value);
 }
 
 static FILE_HANDLE file_create_helper(const char* filename)
@@ -177,7 +177,7 @@ TEST_FUNCTION(write_to_a_file_and_read_from_it)
     ASSERT_ARE_EQUAL(FILE_WRITE_ASYNC_RESULT, FILE_WRITE_ASYNC_OK, file_write_async(file_handle, source, size, 0, write_callback, &write_context));
     
     ///assert
-    wait_on_address_helper(&write_context.value, &write_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&write_context.value, write_context.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, write_context.post_callback_value, interlocked_or(&write_context.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(write_context.did_write_succeed);
 
@@ -185,7 +185,7 @@ TEST_FUNCTION(write_to_a_file_and_read_from_it)
     ASSERT_ARE_EQUAL(FILE_READ_ASYNC_RESULT, FILE_READ_ASYNC_OK, file_read_async(file_handle, destination, sizeof(destination), 0, read_callback, &read_context));
 
     ///assert
-    wait_on_address_helper(&read_context.value, &read_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&read_context.value, read_context.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, read_context.post_callback_value, interlocked_or(&read_context.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(read_context.did_read_succeed);
     ASSERT_ARE_EQUAL(char_ptr, source, destination);
@@ -237,11 +237,11 @@ TEST_FUNCTION(write_twice_to_a_file_contiguously_and_read_from_it)
     ASSERT_ARE_EQUAL(FILE_WRITE_ASYNC_RESULT, FILE_WRITE_ASYNC_OK, file_write_async(file_handle, source2, size, 4, write_callback, &write_context2));
    
     ///assert
-    wait_on_address_helper(&write_context1.value, &write_context1.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&write_context1.value, write_context1.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, write_context1.post_callback_value, interlocked_or(&write_context1.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(write_context1.did_write_succeed);
 
-    wait_on_address_helper(&write_context2.value, &write_context2.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&write_context2.value, write_context2.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, write_context2.post_callback_value, interlocked_or(&write_context2.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(write_context2.did_write_succeed);
 
@@ -249,7 +249,7 @@ TEST_FUNCTION(write_twice_to_a_file_contiguously_and_read_from_it)
     ASSERT_ARE_EQUAL(FILE_READ_ASYNC_RESULT, FILE_READ_ASYNC_OK, file_read_async(file_handle, destination, sizeof(destination), 0, read_callback, &read_context));
 
     ///assert
-    wait_on_address_helper(&read_context.value, &read_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&read_context.value, read_context.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, read_context.post_callback_value, interlocked_or(&read_context.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(read_context.did_read_succeed);
     ASSERT_ARE_EQUAL(char_ptr, "abcdefgh", destination);
@@ -312,11 +312,11 @@ TEST_FUNCTION(write_twice_to_a_file_non_contiguously_and_read_from_it)
     ASSERT_ARE_EQUAL(FILE_WRITE_ASYNC_RESULT, FILE_WRITE_ASYNC_OK, file_write_async(file_handle, source2, size, second_write_position, write_callback, &write_context2));
    
     ///assert
-    wait_on_address_helper(&write_context1.value, &write_context1.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&write_context1.value, write_context1.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, write_context1.post_callback_value, interlocked_or(&write_context1.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(write_context1.did_write_succeed);
 
-    wait_on_address_helper(&write_context2.value, &write_context2.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&write_context2.value, write_context2.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, write_context2.post_callback_value, interlocked_or(&write_context2.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(write_context2.did_write_succeed);
 
@@ -325,11 +325,11 @@ TEST_FUNCTION(write_twice_to_a_file_non_contiguously_and_read_from_it)
     ASSERT_ARE_EQUAL(FILE_READ_ASYNC_RESULT, FILE_READ_ASYNC_OK, file_read_async(file_handle, destination2, sizeof(destination2), second_write_position, read_callback, &read_context2));
 
     ///assert
-    wait_on_address_helper(&read_context1.value, &read_context1.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&read_context1.value, read_context1.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, read_context1.post_callback_value, interlocked_or(&read_context1.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(read_context1.did_read_succeed);
 
-    wait_on_address_helper(&read_context2.value, &read_context2.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&read_context2.value, read_context2.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, read_context2.post_callback_value, interlocked_or(&read_context2.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(read_context2.did_read_succeed);
 
@@ -381,7 +381,7 @@ TEST_FUNCTION(perform_operations_open_write_close_open_read_close)
     ASSERT_IS_NOT_NULL(file_handle1);
 
     ASSERT_ARE_EQUAL(FILE_WRITE_ASYNC_RESULT, FILE_WRITE_ASYNC_OK, file_write_async(file_handle1, source, size, 0, write_callback, &write_context));
-    wait_on_address_helper(&write_context.value, &write_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&write_context.value, write_context.pre_callback_value, UINT32_MAX);
     file_destroy(file_handle1);
    
     ///assert
@@ -396,7 +396,7 @@ TEST_FUNCTION(perform_operations_open_write_close_open_read_close)
     file_destroy(file_handle2);
 
     ///assert
-    wait_on_address_helper(&read_context.value, &read_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&read_context.value, read_context.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, read_context.post_callback_value, interlocked_or(&read_context.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(read_context.did_read_succeed);
     ASSERT_ARE_EQUAL(char_ptr, source, destination);
@@ -430,7 +430,7 @@ TEST_FUNCTION(read_across_eof_fails)
 
     ///assert
 
-    wait_on_address_helper(&write_context.value, &write_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&write_context.value, write_context.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, write_context.post_callback_value, interlocked_or(&write_context.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(write_context.did_write_succeed);
 
@@ -438,7 +438,7 @@ TEST_FUNCTION(read_across_eof_fails)
     file_read_async(file_handle, destination, sizeof(destination), read_position, read_callback, &read_context);
 
     ///assert
-    wait_on_address_helper(&read_context.value, &read_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&read_context.value, read_context.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, read_context.post_callback_value, interlocked_or(&read_context.value, 0), "value should be post_callback_value");
     ASSERT_IS_FALSE(read_context.did_read_succeed);
 
@@ -473,7 +473,7 @@ TEST_FUNCTION(read_beyond_eof_fails)
     ASSERT_ARE_EQUAL(FILE_WRITE_ASYNC_RESULT, FILE_WRITE_ASYNC_OK, file_write_async(file_handle, source, size, 0, write_callback, &write_context));
     
 
-    wait_on_address_helper(&write_context.value, &write_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&write_context.value, write_context.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, write_context.post_callback_value, interlocked_or(&write_context.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(write_context.did_write_succeed);
 
@@ -481,7 +481,7 @@ TEST_FUNCTION(read_beyond_eof_fails)
     file_read_async(file_handle, destination, sizeof(destination), read_position, read_callback, &read_context);
 
     ///assert
-    wait_on_address_helper(&read_context.value, &read_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&read_context.value, read_context.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, read_context.post_callback_value, interlocked_or(&read_context.value, 0), "value should be post_callback_value");
     ASSERT_IS_FALSE(read_context.did_read_succeed);
 
@@ -528,7 +528,7 @@ TEST_FUNCTION(large_simultaneous_writes_succeed)
 
     for (int i = 0; i < num_blocks; ++i)
     {
-        wait_on_address_helper(&contexts[i].value, &contexts[i].pre_callback_value, UINT32_MAX);
+        wait_on_address_helper(&contexts[i].value, contexts[i].pre_callback_value, UINT32_MAX);
         ASSERT_ARE_EQUAL(int32_t, contexts[i].post_callback_value, interlocked_or(&contexts[i].value, 0), "value should be post_callback_value");
         ASSERT_IS_TRUE(contexts[i].did_write_succeed);
     }
@@ -542,7 +542,7 @@ TEST_FUNCTION(large_simultaneous_writes_succeed)
     read_context.post_callback_value = 1;
 
     ASSERT_ARE_EQUAL(FILE_READ_ASYNC_RESULT, FILE_WRITE_ASYNC_OK, file_read_async(file_handle, destination, block_size * num_blocks, 0, read_callback, &read_context));
-    wait_on_address_helper(&read_context.value, &read_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&read_context.value, read_context.pre_callback_value, UINT32_MAX);
     ASSERT_ARE_EQUAL(int32_t, read_context.post_callback_value, interlocked_or(&read_context.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(read_context.did_read_succeed);
 
@@ -596,7 +596,7 @@ TEST_FUNCTION(large_simultaneous_reads_succeed)
     FILE_HANDLE file_handle = file_create_helper(filename);
 
     ASSERT_ARE_EQUAL(FILE_WRITE_ASYNC_RESULT, FILE_WRITE_ASYNC_OK, file_write_async(file_handle, source, block_size * num_blocks, 0, write_callback, &write_context));
-    wait_on_address_helper(&write_context.value, &write_context.pre_callback_value, UINT32_MAX);
+    wait_on_address_helper(&write_context.value, write_context.pre_callback_value, UINT32_MAX);
 
     ASSERT_ARE_EQUAL(int32_t, write_context.post_callback_value, interlocked_or(&write_context.value, 0), "value should be post_callback_value");
     ASSERT_IS_TRUE(write_context.did_write_succeed);
@@ -618,7 +618,7 @@ TEST_FUNCTION(large_simultaneous_reads_succeed)
 
     for (int i = 0; i < num_blocks; ++i)
     {
-        wait_on_address_helper(&contexts[i].value, &contexts[i].pre_callback_value, UINT32_MAX);
+        wait_on_address_helper(&contexts[i].value, contexts[i].pre_callback_value, UINT32_MAX);
         ASSERT_ARE_EQUAL(int32_t, contexts[i].post_callback_value, interlocked_or(&contexts[i].value, 0), "value should be post_callback_value");
         ASSERT_IS_TRUE(contexts[i].did_read_succeed);
     }

--- a/interfaces/tests/sync_int/sync_int.c
+++ b/interfaces/tests/sync_int/sync_int.c
@@ -32,7 +32,7 @@ static int increment_on_odd_values(void* address)
         int32_t value = interlocked_add(ptr, 0);
         while (value % 2 != 1)
         {
-            ASSERT_IS_TRUE(wait_on_address(ptr, &value, UINT32_MAX));
+            ASSERT_IS_TRUE(wait_on_address(ptr, value, UINT32_MAX));
             value = interlocked_add(ptr, 0);
         }
         (void)interlocked_increment(ptr);
@@ -50,7 +50,7 @@ static int increment_on_even_values(void* address)
         int value = interlocked_add(ptr, 0);
         while(value % 2 != 0)
         {
-            ASSERT_IS_TRUE(wait_on_address(ptr, &value, UINT32_MAX));
+            ASSERT_IS_TRUE(wait_on_address(ptr, value, UINT32_MAX));
             value = interlocked_add(ptr, 0);
         }
         (void)interlocked_increment(ptr);
@@ -67,7 +67,7 @@ static int increment_on_wake_up(void* address)
     int32_t value = interlocked_add(ptr, 0);
     (void)interlocked_increment(&create_count);
     wake_by_address_single(&create_count);
-    ASSERT_IS_TRUE(wait_on_address(ptr, &value, UINT32_MAX));
+    ASSERT_IS_TRUE(wait_on_address(ptr, value, UINT32_MAX));
     (void)interlocked_increment(ptr);
 
     return 0;
@@ -149,7 +149,7 @@ TEST_FUNCTION(wake_up_all_threads)
     int current_create_count = interlocked_add(&create_count, 0);
     while (current_create_count < 100)
     {
-        ASSERT_IS_TRUE(wait_on_address(&create_count, &current_create_count, UINT32_MAX));
+        ASSERT_IS_TRUE(wait_on_address(&create_count, current_create_count, UINT32_MAX));
         current_create_count = interlocked_add(&create_count, 0);
     }
     wake_by_address_all(&var);
@@ -173,7 +173,7 @@ TEST_FUNCTION(wait_on_address_returns_immediately)
     int value = 1;
 
     ///act
-    bool return_val = wait_on_address(&var, &value, UINT32_MAX);
+    bool return_val = wait_on_address(&var, value, UINT32_MAX);
 
     ///assert
     ASSERT_IS_TRUE(return_val, "wait_on_address should have returned true");
@@ -194,7 +194,7 @@ TEST_FUNCTION(wait_on_address_returns_after_timeout_elapses)
 
     /// act
     double start_time = timer_global_get_elapsed_ms();
-    bool return_val = wait_on_address(&var, &value, timeout);
+    bool return_val = wait_on_address(&var, value, timeout);
     double time_elapsed = timer_global_get_elapsed_ms() - start_time;
 
     ///assert

--- a/linux/devdoc/sync_linux_requirements.md
+++ b/linux/devdoc/sync_linux_requirements.md
@@ -8,7 +8,7 @@
 ## Exposed API
 
 ```c
-MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t*, compare_address, uint32_t, timeout_ms);
+MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t, compare_value, uint32_t, timeout_ms);
 MOCKABLE_FUNCTION(, void, wake_by_address_all, volatile_atomic int32_t*, address);
 MOCKABLE_FUNCTION(, void, wake_by_address_single, volatile_atomic int32_t*, address);
 ```
@@ -16,13 +16,13 @@ MOCKABLE_FUNCTION(, void, wake_by_address_single, volatile_atomic int32_t*, addr
 ## wait_on_address
 
 ```c
-MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t*, compare_address, uint32_t, timeout_ms)
+MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t, compare_value, uint32_t, timeout_ms)
 ```
 
 **SRS_SYNC_LINUX_43_001: [** `wait_on_address` shall initialize a `timespec` struct with `.tv_nsec` equal to `timeout_ms* 10^6`. **]**
 
 
-**SRS_SYNC_LINUX_43_002: [** `wait_on_address` shall call `syscall` from `sys/syscall.h` with arguments `SYS_futex`, `address`, `FUTEX_WAIT_PRIVATE`, `*compare_address`, `*timeout_struct`, `NULL`, `0`. **]**
+**SRS_SYNC_LINUX_43_002: [** `wait_on_address` shall call `syscall` from `sys/syscall.h` with arguments `SYS_futex`, `address`, `FUTEX_WAIT_PRIVATE`, `compare_value`, `*timeout_struct`, `NULL`, `0`. **]**
 
 **SRS_SYNC_LINUX_43_003: [** `wait_on_address` shall return `true` if `syscall` returns `0`.**]**
 

--- a/linux/src/sync_linux.c
+++ b/linux/src/sync_linux.c
@@ -8,7 +8,7 @@
 #include <time.h>
 #include "azure_c_pal/sync.h"
 
-IMPLEMENT_MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t*, compare_address, uint32_t, timeout_ms)
+IMPLEMENT_MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t, compare_value, uint32_t, timeout_ms)
 {
     /*Codes_SRS_SYNC_43_001: [ wait_on_address shall atomically compare *address and *compare_address.]*/
     /*Codes_SRS_SYNC_43_002: [ wait_on_address shall immediately return true if *address is not equal to *compare_address.]*/
@@ -19,10 +19,10 @@ IMPLEMENT_MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, a
     /*Codes_SRS_SYNC_LINUX_43_001: [ wait_on_address shall initialize a timespec struct with .tv_nsec equal to timeout_ms* 10^6. ]*/
     struct timespec timeout = {timeout_ms / 1000, (timeout_ms % 1000) * 1e6 };
 
-    /*Codes_SRS_SYNC_LINUX_43_002: [ wait_on_address shall call syscall from sys/syscall.h with arguments SYS_futex, address, FUTEX_WAIT_PRIVATE, *compare_address, *timeout_struct, NULL, 0. ]*/
+    /*Codes_SRS_SYNC_LINUX_43_002: [ wait_on_address shall call syscall from sys/syscall.h with arguments SYS_futex, address, FUTEX_WAIT_PRIVATE, compare_value, *timeout_struct, NULL, 0. ]*/
     /*Codes_SRS_SYNC_LINUX_43_003: [ wait_on_address shall return true if syscall returns 0.]*/
     /*Codes_SRS_SYNC_LINUX_43_004: [ wait_on_address shall return false if syscall does not return 0.]*/
-    return syscall(SYS_futex, address, FUTEX_WAIT_PRIVATE, *compare_address, &timeout, NULL, 0) == 0;
+    return syscall(SYS_futex, address, FUTEX_WAIT_PRIVATE, compare_value, &timeout, NULL, 0) == 0;
     
 }
 IMPLEMENT_MOCKABLE_FUNCTION(, void, wake_by_address_all, volatile_atomic int32_t*, address)

--- a/linux/tests/sync_linux_ut/sync_linux_ut.c
+++ b/linux/tests/sync_linux_ut/sync_linux_ut.c
@@ -89,22 +89,21 @@ TEST_FUNCTION_CLEANUP(cleans)
     TEST_MUTEX_RELEASE(g_testByTest);
 }
 
-/*Tests_SRS_SYNC_LINUX_43_002: [ wait_on_address shall call syscall from sys/syscall.h with arguments SYS_futex, address, FUTEX_WAIT_PRIVATE, *compare_address, timeout_struct, NULL, NULL. ]*/
+/*Tests_SRS_SYNC_LINUX_43_002: [ wait_on_address shall call syscall from sys/syscall.h with arguments SYS_futex, address, FUTEX_WAIT_PRIVATE, compare_value, timeout_struct, NULL, NULL. ]*/
 /*Tests_SRS_SYNC_LINUX_43_003: [ wait_on_address shall return true if syscall returns 0.]*/
 
 TEST_FUNCTION(wait_on_address_calls_syscall_successfully)
 {
     ///arrange
     volatile_atomic int32_t var;
-    int32_t val = INT32_MAX;
-    (void)atomic_exchange(&var, val);
+    (void)atomic_exchange(&var, INT32_MAX);
     check_timeout = true;
     expected_timeout_ms = 100;
     expected_return_val = 0;
-    STRICT_EXPECTED_CALL(mock_syscall(SYS_futex, (int32_t*)&var, FUTEX_WAIT_PRIVATE, val, IGNORED_ARG, NULL, 0));
+    STRICT_EXPECTED_CALL(mock_syscall(SYS_futex, (int32_t*)&var, FUTEX_WAIT_PRIVATE, INT32_MAX, IGNORED_ARG, NULL, 0));
 
     ///act
-    bool return_val = wait_on_address(&var, &val, expected_timeout_ms);
+    bool return_val = wait_on_address(&var, INT32_MAX, expected_timeout_ms);
 
     ///assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Actual calls differ from expected calls");
@@ -125,7 +124,7 @@ TEST_FUNCTION(wait_on_address_calls_sycall_unsuccessfully)
     STRICT_EXPECTED_CALL(mock_syscall(SYS_futex, (int*)&var, FUTEX_WAIT_PRIVATE, val, IGNORED_ARG, NULL, 0));
 
     ///act
-    bool return_val = wait_on_address(&var, &val, expected_timeout_ms);
+    bool return_val = wait_on_address(&var, val, expected_timeout_ms);
 
     ///assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Actual calls differ from expected calls");

--- a/win32/devdoc/sync_win32_requirements.md
+++ b/win32/devdoc/sync_win32_requirements.md
@@ -8,7 +8,7 @@
 ## Exposed API
 
 ```c
-MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t*, compare_address, uint32_t, timeout_ms);
+MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t, compare_value, uint32_t, timeout_ms);
 MOCKABLE_FUNCTION(, void, wake_by_address_all, volatile_atomic int32_t*, address);
 MOCKABLE_FUNCTION(, void, wake_by_address_single, volatile_atomic int32_t*, address);
 ```
@@ -16,10 +16,10 @@ MOCKABLE_FUNCTION(, void, wake_by_address_single, volatile_atomic int32_t*, addr
 ## wait_on_address
 
 ```c
-MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t*, compare_address, uint32_t, timeout_ms)
+MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t, compare_value, uint32_t, timeout_ms)
 ```
 
-**SRS_SYNC_WIN32_43_001: [** `wait_on_address` shall call `WaitOnAddress` from `windows.h` with `address` as `Address`, `compare_address` as `CompareAddress`, `4` as `AddressSize` and `timeout_ms` as `dwMilliseconds`. **]**
+**SRS_SYNC_WIN32_43_001: [** `wait_on_address` shall call `WaitOnAddress` from `windows.h` with `address` as `Address`, a pointer to the value `compare_value` as `CompareAddress`, `4` as `AddressSize` and `timeout_ms` as `dwMilliseconds`. **]**
 
 **SRS_SYNC_WIN32_43_002: [** `wait_on_address` shall return the return value of `WaitOnAddress` **]**
 

--- a/win32/src/sync_win32.c
+++ b/win32/src/sync_win32.c
@@ -8,11 +8,11 @@
 #include "windows.h"
 #include "azure_c_pal/sync.h"
 
-IMPLEMENT_MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t*, compare_address, uint32_t, timeout_ms)
+IMPLEMENT_MOCKABLE_FUNCTION(, bool, wait_on_address, volatile_atomic int32_t*, address, int32_t, compare_value, uint32_t, timeout_ms)
 {
-    /*Codes_SRS_SYNC_WIN32_43_001: [ wait_on_address shall call WaitOnAddress from windows.h with address as Address, compare_address as CompareAddress, 4 as AddressSize and timeout_ms as dwMilliseconds. ]*/
+    /*Codes_SRS_SYNC_WIN32_43_001: [ wait_on_address shall call WaitOnAddress from windows.h with address as Address, a pointer to the value compare_value as CompareAddress, 4 as AddressSize and timeout_ms as dwMilliseconds. ]*/
     /*Codes_SRS_SYNC_WIN32_43_002: [ wait_on_address shall return the return value of WaitOnAddress ]*/
-    return WaitOnAddress(address, compare_address, sizeof(*compare_address), timeout_ms);
+    return WaitOnAddress(address, &compare_value, sizeof(int32_t), timeout_ms);
 }
 IMPLEMENT_MOCKABLE_FUNCTION(, void, wake_by_address_all, volatile_atomic int32_t*, address)
 {

--- a/win32/tests/sync_win32_ut/sync_win32_ut.c
+++ b/win32/tests/sync_win32_ut/sync_win32_ut.c
@@ -82,40 +82,42 @@ TEST_FUNCTION_CLEANUP(cleans)
     TEST_MUTEX_RELEASE(g_testByTest);
 }
 
-/*Tests_SRS_SYNC_WIN32_43_001: [ wait_on_address shall call WaitOnAddress from windows.h with address as Address, compare_address as CompareAddress, 4 as AddressSize and timeout_ms as dwMilliseconds. ]*/
+/*Tests_SRS_SYNC_WIN32_43_001: [ wait_on_address shall call WaitOnAddress from windows.h with address as Address, a pointer to the value compare_value as CompareAddress, 4 as AddressSize and timeout_ms as dwMilliseconds. ]*/
 /*Tests_SRS_SYNC_WIN32_43_002: [ wait_on_address shall return the return value of WaitOnAddress ]*/
 TEST_FUNCTION(wait_on_address_calls_WaitOnAddress_successfully)
 {
     ///arrange
     volatile int32_t var;
-    int32_t val = INT32_MAX;
-    (void)InterlockedExchange((volatile LONG*)&var, val);
+    int32_t expected_val = INT32_MAX;
+    (void)InterlockedExchange((volatile LONG*)&var, INT32_MAX);
     uint32_t timeout = 1000;
-    STRICT_EXPECTED_CALL(mock_WaitOnAddress((volatile VOID*)&var, (PVOID)&val, (SIZE_T)4, (DWORD)timeout))
+    STRICT_EXPECTED_CALL(mock_WaitOnAddress((volatile VOID*)&var, IGNORED_ARG, (SIZE_T)4, (DWORD)timeout))
+        .ValidateArgumentBuffer(2, &expected_val, sizeof(expected_val))
         .SetReturn(true);
 
     ///act
-    bool return_val = wait_on_address(&var, &val, timeout);
+    bool return_val = wait_on_address(&var, INT32_MAX, timeout);
 
     ///assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Actual calls differ from expected calls");
     ASSERT_IS_TRUE(return_val, "Return value is incorrect");
 }
 
-/*Tests_SRS_SYNC_WIN32_43_001: [ wait_on_address shall call WaitOnAddress from windows.h with address as Address, compare_address as CompareAddress, 4 as AddressSize and timeout_ms as dwMilliseconds. ]*/
+/*Tests_SRS_SYNC_WIN32_43_001: [ wait_on_address shall call WaitOnAddress from windows.h with address as Address, a pointer to the value compare_value as CompareAddress, 4 as AddressSize and timeout_ms as dwMilliseconds. ]*/
 /*Tests_SRS_SYNC_WIN32_43_002: [ wait_on_address shall return the return value of WaitOnAddress ]*/
 TEST_FUNCTION(wait_on_address_calls_WaitOnAddress_unsuccessfully)
 {
     ///arrange
     volatile int32_t var;
-    int32_t val = INT32_MAX;
-    (void)InterlockedExchange((volatile LONG*)&var, val);
+    int32_t expected_val = INT32_MAX;
+    (void)InterlockedExchange((volatile LONG*)&var, INT32_MAX);
     uint32_t timeout = 1000;
-    STRICT_EXPECTED_CALL(mock_WaitOnAddress((volatile VOID*)&var, (PVOID)&val, (SIZE_T)4, (DWORD)timeout))
+    STRICT_EXPECTED_CALL(mock_WaitOnAddress((volatile VOID*)&var, IGNORED_ARG, (SIZE_T)4, (DWORD)timeout))
+        .ValidateArgumentBuffer(2, &expected_val, sizeof(expected_val))
         .SetReturn(false);
 
     ///act
-    bool return_val = wait_on_address(&var, &val, timeout);
+    bool return_val = wait_on_address(&var, INT32_MAX, timeout);
 
     ///assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Actual calls differ from expected calls");


### PR DESCRIPTION
Modify wait_on_address to have a value rather than address. It helps with enum usage. All our usage is waiting for a specific value, most of them being enum values, so passing the int32_t value rather than the address helps with preserving the type for the debugging sessions.