### PR TITLE
Fix socket handle leak: always call closesocket/close after shutdown in disconnect

### DIFF
--- a/linux/devdoc/socket_transport_linux_requirements.md
+++ b/linux/devdoc/socket_transport_linux_requirements.md
@@ -183,8 +183,6 @@ MOCKABLE_FUNCTION(, void, socket_transport_disconnect, SOCKET_TRANSPORT_HANDLE, 
 
 **SRS_SOCKET_TRANSPORT_LINUX_11_025: [** `socket_transport_disconnect` shall call `shutdown` to stop both the transmit and reception of the connected socket. **]**
 
-**SRS_SOCKET_TRANSPORT_LINUX_11_026: [** If `shutdown` does not return 0, the socket is not valid therefore `socket_transport_disconnect` shall not call 'close' **]**
-
 **SRS_SOCKET_TRANSPORT_LINUX_11_023: [** `socket_transport_disconnect` shall call `close` to disconnect the connected socket. **]**
 
 **SRS_SOCKET_TRANSPORT_LINUX_11_024: [** `socket_transport_disconnect` shall call `sm_close_end`. **]**

--- a/linux/src/socket_transport_linux.c
+++ b/linux/src/socket_transport_linux.c
@@ -340,16 +340,13 @@ void socket_transport_disconnect(SOCKET_TRANSPORT_HANDLE socket_transport)
             // Codes_SRS_SOCKET_TRANSPORT_LINUX_11_025: [ socket_transport_disconnect shall call shutdown to stop both the transmit and reception of the connected socket. ]
             if (shutdown(socket_transport->socket, 2) != 0)
             {
-                // Codes_SRS_SOCKET_TRANSPORT_LINUX_11_026: [ If shutdown does not return 0, the socket is not valid therefore socket_transport_disconnect shall not call 'close' ]
                 LogErrorNo("shutdown failed on socket: %" PRI_SOCKET "", socket_transport->socket);
             }
-            else
+
+            // Codes_SRS_SOCKET_TRANSPORT_LINUX_11_023: [ socket_transport_disconnect shall call close to disconnect the connected socket. ]
+            if (close(socket_transport->socket) != 0)
             {
-                // Codes_SRS_SOCKET_TRANSPORT_LINUX_11_023: [ socket_transport_disconnect shall call close to disconnect the connected socket. ]
-                if (close(socket_transport->socket) != 0)
-                {
-                    LogErrorNo("Close failure on socket: %" PRI_SOCKET "", socket_transport->socket);
-                }
+                LogErrorNo("Close failure on socket: %" PRI_SOCKET "", socket_transport->socket);
             }
             // Codes_SRS_SOCKET_TRANSPORT_LINUX_11_024: [ socket_transport_disconnect shall call sm_close_end. ]
             sm_close_end(socket_transport->sm);

--- a/linux/tests/socket_transport_linux_ut/socket_transport_linux_ut.c
+++ b/linux/tests/socket_transport_linux_ut/socket_transport_linux_ut.c
@@ -511,7 +511,7 @@ TEST_FUNCTION(socket_transport_disconnect_close_fail_succeed)
     socket_transport_destroy(socket_handle);
 }
 
-/*Tests_SRS_SOCKET_TRANSPORT_LINUX_11_026: [ If shutdown does not return 0, the socket is not valid therefore socket_transport_disconnect shall not call 'close' ]*/
+/*Tests_SRS_SOCKET_TRANSPORT_LINUX_11_023: [ socket_transport_disconnect shall call close to disconnect the connected socket. ]*/
 TEST_FUNCTION(socket_transport_disconnect_shutdown_fail_succeed)
 {
     //arrange
@@ -529,6 +529,8 @@ TEST_FUNCTION(socket_transport_disconnect_shutdown_fail_succeed)
     STRICT_EXPECTED_CALL(sm_close_begin(IGNORED_ARG));
     STRICT_EXPECTED_CALL(shutdown(IGNORED_ARG, 2))
         .SetReturn(MU_FAILURE);
+    STRICT_EXPECTED_CALL(close(IGNORED_ARG))
+        .SetReturn(0);
     STRICT_EXPECTED_CALL(sm_close_end(IGNORED_ARG));
 
     //act

--- a/win32/devdoc/socket_transport_win32_requirements.md
+++ b/win32/devdoc/socket_transport_win32_requirements.md
@@ -209,7 +209,7 @@ MOCKABLE_FUNCTION(, void, socket_transport_disconnect, SOCKET_TRANSPORT_HANDLE, 
 
 **SRS_SOCKET_TRANSPORT_WIN32_09_029: [** If `sm_close_begin` does not return `SM_EXEC_GRANTED`, `socket_transport_disconnect` shall fail and return. **]**
 
-**SRS_SOCKET_TRANSPORT_WIN32_09_083: [** If `shutdown` does not return 0 on a socket that is not a binding socket, the socket is not valid therefore `socket_transport_disconnect` shall not call `close` **]**
+**SRS_SOCKET_TRANSPORT_WIN32_09_083: [** If the type is not `SOCKET_BINDING`, `socket_transport_disconnect` shall call `shutdown`. **]**
 
 **SRS_SOCKET_TRANSPORT_WIN32_09_030: [** `socket_transport_disconnect` shall call `closesocket` to disconnect the connected socket. **]**
 

--- a/win32/src/socket_transport_win32.c
+++ b/win32/src/socket_transport_win32.c
@@ -382,18 +382,19 @@ void socket_transport_disconnect(SOCKET_TRANSPORT_HANDLE socket_transport)
         SM_RESULT close_result = sm_close_begin(socket_transport->sm);
         if (close_result == SM_EXEC_GRANTED)
         {
-            // Codes_SRS_SOCKET_TRANSPORT_WIN32_09_083: [ If shutdown does not return 0 on a socket that is not a binding socket, the socket is not valid therefore socket_transport_disconnect shall not call close ]
-            if (socket_transport->type != SOCKET_BINDING && shutdown(socket_transport->socket, SD_BOTH) != 0)
+            // Codes_SRS_SOCKET_TRANSPORT_WIN32_09_083: [ If the type is not SOCKET_BINDING, socket_transport_disconnect shall call shutdown. ]
+            if (socket_transport->type != SOCKET_BINDING)
             {
-                LogLastError("shutdown failed on socket: %" PRI_SOCKET "", socket_transport->socket);
-            }
-            else
-            {
-                // Codes_SRS_SOCKET_TRANSPORT_WIN32_09_030: [ socket_transport_disconnect shall call closesocket to disconnect the connected socket. ]
-                if (closesocket(socket_transport->socket) != 0)
+                if (shutdown(socket_transport->socket, SD_BOTH) != 0)
                 {
-                    LogLastError("Failure in closesocket %" PRI_SOCKET "", socket_transport->socket);
+                    LogLastError("shutdown failed on socket: %" PRI_SOCKET "", socket_transport->socket);
                 }
+            }
+
+            // Codes_SRS_SOCKET_TRANSPORT_WIN32_09_030: [ socket_transport_disconnect shall call closesocket to disconnect the connected socket. ]
+            if (closesocket(socket_transport->socket) != 0)
+            {
+                LogLastError("Failure in closesocket %" PRI_SOCKET "", socket_transport->socket);
             }
             // Codes_SRS_SOCKET_TRANSPORT_WIN32_09_031: [ socket_transport_disconnect shall call sm_close_end. ]
             sm_close_end(socket_transport->sm);

--- a/win32/tests/socket_transport_win32_ut/socket_transport_win32_ut.c
+++ b/win32/tests/socket_transport_win32_ut/socket_transport_win32_ut.c
@@ -674,7 +674,8 @@ TEST_FUNCTION(socket_transport_disconnect_invalid_arguments)
 
 }
 
-/*Tests_SRS_SOCKET_TRANSPORT_WIN32_09_083: [ If shutdown does not return 0 on a socket that is not a binding socket, the socket is not valid therefore socket_transport_disconnect shall not call close]*/
+/*Tests_SRS_SOCKET_TRANSPORT_WIN32_09_083: [ If the type is not SOCKET_BINDING, socket_transport_disconnect shall call shutdown. ]*/
+/*Tests_SRS_SOCKET_TRANSPORT_WIN32_09_030: [ socket_transport_disconnect shall call closesocket to disconnect the connected socket. ]*/
 TEST_FUNCTION(socket_transport_disconnect_shutdown_fail)
 {
     //arrange
@@ -692,6 +693,8 @@ TEST_FUNCTION(socket_transport_disconnect_shutdown_fail)
     STRICT_EXPECTED_CALL(sm_close_begin(IGNORED_ARG));
     STRICT_EXPECTED_CALL(shutdown(IGNORED_ARG, 2))
         .SetReturn(MU_FAILURE);
+    STRICT_EXPECTED_CALL(closesocket(IGNORED_ARG))
+        .SetReturn(0);
     STRICT_EXPECTED_CALL(sm_close_end(IGNORED_ARG));
 
     //act
@@ -736,7 +739,7 @@ TEST_FUNCTION(socket_transport_disconnect_failure_closesocket)
     socket_transport_destroy(socket_handle);
 }
 
-/*Tests_SRS_SOCKET_TRANSPORT_WIN32_09_083: [ If shutdown does not return 0 on a socket that is not a binding socket, the socket is not valid therefore socket_transport_disconnect shall not call close ]*/
+/*Tests_SRS_SOCKET_TRANSPORT_WIN32_09_083: [ If the type is not SOCKET_BINDING, socket_transport_disconnect shall call shutdown. ]*/
 TEST_FUNCTION(socket_transport_disconnect_binding_socket_closesocket)
 {
     //arrange


### PR DESCRIPTION
## Summary

Fixes socket handle leaks in \socket_transport_disconnect()\ detected by VLD in integration tests.

**Root cause:** When \shutdown()\ failed on non-binding sockets, \closesocket()\/\close()\ was skipped due to an \if/else\ structure, leaking the socket handle and associated Winsock internal allocations (\WahInsertHandleContext\, 256 bytes each).

**Fix:** Ensure \closesocket()\/\close()\ is always called regardless of \shutdown()\ result. Per Windows/POSIX docs, \shutdown()\ is for graceful connection termination while \closesocket()\/\close()\ releases the socket descriptor and must always be called.

## Changes
- **win32/src/socket_transport_win32.c**: Restructured disconnect to always call \closesocket()\
- **linux/src/socket_transport_linux.c**: Restructured disconnect to always call \close()\
- **win32/devdoc/socket_transport_win32_requirements.md**: Updated SRS_SOCKET_TRANSPORT_WIN32_09_083
- **linux/devdoc/socket_transport_linux_requirements.md**: Updated SRS_SOCKET_TRANSPORT_LINUX_11_026
- **win32/tests/socket_transport_win32_ut**: Updated unit test expectations
- **linux/tests/socket_transport_linux_ut**: Updated unit test expectations

## Testing
- Γ£à Unit tests pass (socket_transport_win32_ut, socket_transport_linux_ut)
- Γ£à Integration tests pass (socket_transport_int)

Fixes AB#37142411


---
Session ID: `62cfb822-ac74-4d9a-96e3-7bded6ab46d2`

