### PR TITLE
Add real_ps_util_renames to real_process_watchdog to avoid c_pal link in UTs

### DIFF
--- a/common/tests/threadpool_int/CMakeLists.txt
+++ b/common/tests/threadpool_int/CMakeLists.txt
@@ -12,4 +12,4 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/c_pal" ADDITIONAL_LIBS real_process_watchdog c_pal_ll_reals pal_interfaces c_pal)
+build_test_artifacts(${theseTestsName} "tests/c_pal" ADDITIONAL_LIBS real_process_watchdog c_pal_reals pal_interfaces c_pal)

--- a/common/tests/threadpool_int/CMakeLists.txt
+++ b/common/tests/threadpool_int/CMakeLists.txt
@@ -12,4 +12,4 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/c_pal" ADDITIONAL_LIBS real_process_watchdog c_pal_reals pal_interfaces c_pal)
+build_test_artifacts(${theseTestsName} "tests/c_pal" ADDITIONAL_LIBS pal_interfaces c_pal c_pal_reals)

--- a/common/tests/threadpool_int/threadpool_int.c
+++ b/common/tests/threadpool_int/threadpool_int.c
@@ -13,6 +13,8 @@
 
 #include "testrunnerswitcher.h"
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c.h" // IWYU pragma: keep
 
 #include "c_pal/timer.h"

--- a/interfaces/tests/srw_lock_int/CMakeLists.txt
+++ b/interfaces/tests/srw_lock_int/CMakeLists.txt
@@ -12,5 +12,5 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/c_pal/int" ADDITIONAL_LIBS real_process_watchdog c_pal_ll_reals c_pal)
+build_test_artifacts(${theseTestsName} "tests/c_pal/int" ADDITIONAL_LIBS real_process_watchdog c_pal_reals c_pal)
 

--- a/interfaces/tests/srw_lock_int/CMakeLists.txt
+++ b/interfaces/tests/srw_lock_int/CMakeLists.txt
@@ -12,5 +12,5 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/c_pal/int" ADDITIONAL_LIBS real_process_watchdog c_pal_reals c_pal)
+build_test_artifacts(${theseTestsName} "tests/c_pal/int" ADDITIONAL_LIBS c_pal)
 

--- a/interfaces/tests/srw_lock_int/srw_lock_int.c
+++ b/interfaces/tests/srw_lock_int/srw_lock_int.c
@@ -6,8 +6,6 @@
 
 #include "testrunnerswitcher.h"
 
-#include "umock_c/umock_c.h" // IWYU pragma: keep
-
 #include "c_pal/srw_lock.h"
 #include "c_pal/timed_test_suite.h"
 

--- a/interfaces/tests/srw_lock_ll_int/CMakeLists.txt
+++ b/interfaces/tests/srw_lock_ll_int/CMakeLists.txt
@@ -12,5 +12,5 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/c_pal/int" ADDITIONAL_LIBS real_process_watchdog c_pal_ll_reals c_pal)
+build_test_artifacts(${theseTestsName} "tests/c_pal/int" ADDITIONAL_LIBS real_process_watchdog c_pal_reals c_pal)
 

--- a/interfaces/tests/srw_lock_ll_int/CMakeLists.txt
+++ b/interfaces/tests/srw_lock_ll_int/CMakeLists.txt
@@ -12,5 +12,5 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/c_pal/int" ADDITIONAL_LIBS real_process_watchdog c_pal_reals c_pal)
+build_test_artifacts(${theseTestsName} "tests/c_pal/int" ADDITIONAL_LIBS c_pal)
 

--- a/interfaces/tests/srw_lock_ll_int/srw_lock_ll_int.c
+++ b/interfaces/tests/srw_lock_ll_int/srw_lock_ll_int.c
@@ -5,8 +5,6 @@
 
 #include "testrunnerswitcher.h"
 
-#include "umock_c/umock_c.h" // IWYU pragma: keep
-
 #include "c_pal/srw_lock_ll.h"
 #include "c_pal/timed_test_suite.h"
 

--- a/linux/linux_reals/real_process_watchdog.c
+++ b/linux/linux_reals/real_process_watchdog.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include "real_interlocked_renames.h" // IWYU pragma: keep
+#include "real_ps_util_renames.h" // IWYU pragma: keep
 
 #include "real_process_watchdog_renames.h" // IWYU pragma: keep
 

--- a/win32/reals/real_process_watchdog.c
+++ b/win32/reals/real_process_watchdog.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include "real_interlocked_renames.h" // IWYU pragma: keep
+#include "real_ps_util_renames.h" // IWYU pragma: keep
 
 #include "real_process_watchdog_renames.h" // IWYU pragma: keep
 

--- a/win32/tests/gballoc_ll_passthrough_ut/gballoc_ll_passthrough_ut_pch.h
+++ b/win32/tests/gballoc_ll_passthrough_ut/gballoc_ll_passthrough_ut_pch.h
@@ -10,6 +10,9 @@
 
 #include "macro_utils/macro_utils.h"
 #include "testrunnerswitcher.h"
+
+#include "umock_c/umock_c.h"
+
 #include "c_pal/timed_test_suite.h"
 
 #endif // GBALLOC_LL_PASSTHROUGH_UT_PCH_H


### PR DESCRIPTION
This PR makes `real_process_watchdog` self-contained by adding `real_ps_util_renames.h` to its compilation. Previously, `real_process_watchdog` called `ps_util_terminate_process` (via `LogCriticalAndTerminate`), requiring downstream UTs to link `c_pal`. Now `ps_util_terminate_process` is renamed to `real_ps_util_terminate_process`, which is provided by `c_pal_reals` (already linked in all UTs).

**Changes:**
- `win32/reals/real_process_watchdog.c` + `linux/linux_reals/real_process_watchdog.c`: Add `#include "real_ps_util_renames.h"`
- 3 int test CMakeLists (`srw_lock_int`, `srw_lock_ll_int`, `threadpool_int`): Change `c_pal_ll_reals` to `c_pal_reals` to provide `real_ps_util_terminate_process`
- `gballoc_ll_passthrough_ut` PCH: Add `umock_c.h` before `timed_test_suite.h` for proper rename activation

This enables downstream repos (c-util, etc.) to avoid linking `c_pal` in unit tests solely for watchdog support.
